### PR TITLE
Remove unused doScan: function, temp comment out (and mark for possib…

### DIFF
--- a/geofencingTest/Base.lproj/Main.storyboard
+++ b/geofencingTest/Base.lproj/Main.storyboard
@@ -22,13 +22,15 @@
                                 <rect key="frame" x="20" y="28" width="560" height="472"/>
                                 <gestureRecognizers/>
                                 <connections>
-                                    <outletCollection property="gestureRecognizers" destination="rWm-In-cbu" appends="YES" id="0Ko-a1-wmB"/>
                                     <outletCollection property="gestureRecognizers" destination="lts-1Q-cEa" appends="YES" id="4Qz-5T-6yn"/>
                                 </connections>
                             </mapView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0JC-3w-uMB">
                                 <rect key="frame" x="20" y="520" width="143" height="30"/>
                                 <state key="normal" title="Clear all checkpoints"/>
+                                <connections>
+                                    <action selector="clearAllCheckpoints:" destination="BYZ-38-t0r" eventType="touchUpInside" id="atr-6G-Kge"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
@@ -47,7 +49,6 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
-                <tapGestureRecognizer id="rWm-In-cbu"/>
                 <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="lts-1Q-cEa">
                     <connections>
                         <action selector="longPressGestureHandler:" destination="BYZ-38-t0r" id="hqN-PV-pbd"/>

--- a/geofencingTest/ViewController.h
+++ b/geofencingTest/ViewController.h
@@ -18,14 +18,18 @@
 @property CLLocationManager *locationManager;
 @property LocationManagerDelegate *locationManagerDelegate;
 @property MapViewLocationUpdatesDelegate *mapViewLocationManagerDelegate;
-@property (strong, nonatomic) IBOutlet UITapGestureRecognizer *mapTapRecognizer;
+
+//Possible delete?
+//@property (strong, nonatomic) IBOutlet UITapGestureRecognizer *mapTapRecognizer;
+
+
 @property (strong, nonatomic) IBOutlet UILongPressGestureRecognizer *mapLongPressGestureRecognizer;
 
 @property (weak, nonatomic) IBOutlet MKMapView *mapView;
 @property (weak, nonatomic) IBOutlet UILabel *scansLabel;
+- (IBAction)clearAllCheckpoints:(id)sender;
 
 - (void)longPressGestureHandler:(UITapGestureRecognizer*)tapGesture;
-- (IBAction)doScan:(id)sender;
 - (void)handleLocationServicesAuthorizationCheck;
 - (void)setUpGeoFences;
 - (void)updateMap:(CGPoint)pointTouched;

--- a/geofencingTest/ViewController.m
+++ b/geofencingTest/ViewController.m
@@ -54,26 +54,30 @@
     //Get user permission to use location services, then start monitoring
     [self handleLocationServicesAuthorizationCheck];
     
+    //delete?
     //Allocate gesture recognizer
-    self.mapTapRecognizer = [[UITapGestureRecognizer alloc] init];
-    self.mapTapRecognizer.numberOfTapsRequired = 2;
-    self.mapTapRecognizer.delegate = self;
+//    self.mapTapRecognizer = [[UITapGestureRecognizer alloc] init];
+//    self.mapTapRecognizer.numberOfTapsRequired = 2;
+//    self.mapTapRecognizer.delegate = self;
     
     //Allocate long-press gesture recognizer
     self.mapLongPressGestureRecognizer = [[UILongPressGestureRecognizer alloc] init];
     self.mapLongPressGestureRecognizer.delegate = self;
 
+//Debug - get all gestures associated with map view
+//    for (UIGestureRecognizer* recognizer in self.mapView.gestureRecognizers) {
+//        NSLog(@"%@",recognizer);
+//    }
+
 }
 
-
+//delete?
 -(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
     for (UITouch *touch in touches) {
         if (touch.tapCount == 2) {
             NSLog(@"Double touched!");
             [self updateMap:[touch locationInView:touch.view]];
         }
-        
-        
     }
 }
 
@@ -103,16 +107,20 @@
 }
 
 
+- (IBAction)clearAllCheckpoints:(id)sender {
+    [self.mapView removeAnnotations:self.mapView.annotations];
+    
+    for (CLCircularRegion *region in self.locationManager.monitoredRegions) {
+        [self.locationManager stopMonitoringForRegion:region];
+    }
+}
+
 - (void)longPressGestureHandler:(UITapGestureRecognizer*)tapGesture{
     if(tapGesture.state == UIGestureRecognizerStateBegan){
         [self updateMap:[tapGesture locationInView:tapGesture.view]];
     }
 }
 
-- (IBAction)doScan:(id)sender {
-    [self handleLocationServicesAuthorizationCheck];
-    self.scansLabel.text = @"Completed Scan";
-}
 
 - (void)handleLocationServicesAuthorizationCheck{
     switch ([CLLocationManager authorizationStatus]) {


### PR DESCRIPTION
…le deletion) tap gesture recognizer set up. The defined tap gesture looks to be conflicting with MKMapView's own internal tap gesture recognizer.

Add in clear all checkpoints functionality (removes all annotations from map, sends message to CLLocationManager to stop monitoring all corresponding geofences .
